### PR TITLE
Pipelines API - basic CRUD functionality

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -25,6 +25,11 @@ The API will be available at `http://localhost:8000`
 - **GET** `/api/documents/{document_id}` - Get a document by ID
 - **PATCH** `/api/documents/{document_id}` - Update a document
 - **DELETE** `/api/documents/{document_id}` - Delete a document
+- **POST** `/api/pipelines` - Create a pipeline
+- **GET** `/api/pipelines` - List all pipelines
+- **GET** `/api/pipelines/{pipeline_id}` - Get a pipeline by ID
+- **PATCH** `/api/pipelines/{pipeline_id}` - Update a pipeline
+- **DELETE** `/api/pipelines/{document_id}` - Delete a pipeline
 
 ## Testing
 E2E Testing for this api is available in the `api-e2e` module. It uses Jest for e2e testing for several reasons:

--- a/api/di/__init__.py
+++ b/api/di/__init__.py
@@ -3,12 +3,14 @@ A DI container for all the global app dependencies
 """
 from service.db_svc import DBService
 from service.documents_svc import DocumentsSvc
+from service.pipelines_svc import PipelineSvc
 
 db_service = None
 documents_service = None
+pipelines_service = None
 
 async def initialize_dependencies():
-    global db_service, documents_service
+    global db_service, documents_service, pipelines_service
 
     db_service = DBService(
         connection_string="postgresql://username:password@localhost:5432/trellis"
@@ -16,6 +18,7 @@ async def initialize_dependencies():
     await db_service.connect()
 
     documents_service = DocumentsSvc(db_service)
+    pipelines_service = PipelineSvc(db_service)
 
 """
 Getter functions that return the singleton instances of each service,
@@ -28,3 +31,6 @@ def get_db_service() -> DBService:
 
 def get_documents_service() -> DocumentsSvc:
     return documents_service
+
+def get_pipelines_service() -> PipelineSvc:
+    return pipelines_service

--- a/api/main.py
+++ b/api/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from contextlib import asynccontextmanager
 from routers.health_routes import router as health_router
 from routers.document_routes import router as document_router
+from routers.pipeline_routes import router as pipeline_router
 from di import initialize_dependencies
 import uvicorn
 
@@ -11,9 +12,11 @@ async def lifespan(app: FastAPI):
     await initialize_dependencies()
     yield
 
-app = FastAPI(lifespan=lifespan)
-app.include_router(health_router, prefix="/api")
-app.include_router(document_router, prefix="/api")
+if __name__ == "__main__":
+    app = FastAPI(lifespan=lifespan)
+    app.include_router(health_router, prefix="/api")
+    app.include_router(document_router, prefix="/api")
+    app.include_router(pipeline_router, prefix="/api")
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/api/model/__init__.py
+++ b/api/model/__init__.py
@@ -1,2 +1,3 @@
 # __init__.py
 from .document import Document, Field, TextField, NumberField, BooleanField, MarkdownField, AttachmentField
+from .pipeline import Pipeline

--- a/api/model/pipeline.py
+++ b/api/model/pipeline.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+@dataclass
+class Pipeline:
+    id: int
+    name: str
+    type: str
+    cron_string: str
+    # TODO: is there a way we can make sure its JSON?
+    configs: str 

--- a/api/routers/pipeline_routes.py
+++ b/api/routers/pipeline_routes.py
@@ -1,0 +1,57 @@
+from schemas.pipeline_schemas import CreatePipelineRequest, UpdatePipelineRequest, PipelineResponse, DeletePipelineResponse
+from typing import Any
+from fastapi import APIRouter, Request, Depends, HTTPException
+from di import get_pipelines_service
+from service.pipelines_svc import PipelineSvc
+
+router = APIRouter()
+
+@router.post("/pipelines")
+async def create_pipeline(
+    request: Request,
+    create_pipeline_request: CreatePipelineRequest,
+    pipeline_service: PipelineSvc = Depends(get_pipelines_service)
+    ) -> PipelineResponse:
+
+    pipeline = await pipeline_service.create_pipeline(create_pipeline_request)
+    return pipeline
+
+@router.get("/pipelines")
+async def get_pipelines(
+    request: Request,
+    pipeline_service: PipelineSvc = Depends(get_pipelines_service)
+) -> list[PipelineResponse]:
+    pipelines = await pipeline_service.list_pipelines()
+    return pipelines
+
+@router.get("/pipelines/{pipeline_id}")
+async def get_pipeline(
+    pipeline_id: int,
+    request: Request,
+    pipeline_service: PipelineSvc = Depends(get_pipelines_service)
+) -> PipelineResponse:
+    pipeline = await pipeline_service.get_pipeline(pipeline_id)
+    if pipeline is None:
+        raise HTTPException(status_code=404, detail="Pipeline not found")
+    return pipeline
+
+@router.patch("/pipelines/{pipeline_id}")
+async def update_pipeline(
+    pipeline_id: int,
+    request: Request,
+    update_request: UpdatePipelineRequest,
+    pipelines_service: PipelineSvc = Depends(get_pipelines_service)
+) -> PipelineResponse:
+    pipeline = await pipelines_service.update_pipeline(pipeline_id, update_request)
+    if pipeline is None:
+        raise HTTPException(status_code=404, detail="Pipeline not found")
+    return pipeline
+
+@router.delete("/pipelines/{pipeline_id}")
+async def delete_pipeline(
+    pipeline_id: int,
+    request: Request,
+    pipelines_service: PipelineSvc = Depends(get_pipelines_service)
+) -> DeletePipelineResponse:
+    await pipelines_service.delete_pipeline(pipeline_id)
+    return {"status": "deleted"}

--- a/api/schemas/pipeline_schemas.py
+++ b/api/schemas/pipeline_schemas.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel
+
+class CreatePipelineRequest(BaseModel):
+    name: str
+    type: str
+    cron_string: str
+    configs: str
+
+class UpdatePipelineRequest(BaseModel):
+    # TODO: Can this be optional?
+    name: str
+    type: str
+    cron_string: str
+    configs: str 
+
+class PipelineResponse(BaseModel):
+    id: int
+    name: str
+    type: str
+    cron_string: str
+    configs: str
+
+class DeletePipelineResponse(BaseModel):
+    status: str

--- a/api/service/pipelines_svc.py
+++ b/api/service/pipelines_svc.py
@@ -1,0 +1,100 @@
+from model import Pipeline
+from schemas.pipeline_schemas import CreatePipelineRequest, UpdatePipelineRequest
+from service.db_svc import DBService
+from typing import Dict, Any
+
+class PipelineSvc():
+        '''
+        Handles basic pipeline CRUD operations using database storage
+        '''
+        def __init__(self, db_svc: DBService):
+                self.db_svc = db_svc
+
+        async def create_pipeline(self, request: CreatePipelineRequest) -> Pipeline:
+            """
+            Create a new pipeline with the provided request data.
+
+            :param request: CreatePipelineRequest object containing pipeline details
+            :return: The newly created Pipeline object
+            """
+            # Insert pipeline record
+            pipeline_result = await self.db_svc.query(
+                "INSERT INTO pipelines (name, type, cron_string, configs) VALUES ($1, $2, $3, $4) RETURNING id, name, type, cron_string, configs, created_at",
+                request.name, 
+                request.type,
+                request.cron_string, 
+                request.configs
+            )
+            
+            pipeline_row = pipeline_result[0]
+            pipeline_id = pipeline_row['id']
+
+            return Pipeline(
+                id=pipeline_id,
+                name=pipeline_row['name'],
+                type=pipeline_row['type'],
+                cron_string=pipeline_row['cron_string'],
+                configs=pipeline_row['configs']
+            )
+
+        async def list_pipelines(self) -> list[Pipeline]:
+            """
+            Retrieve a list of all pipelines.
+            TODO: add basic search/filter parameters
+
+            :return: List of Pipeline objects
+            """
+            pipelines_data = await self.db_svc.query("SELECT id FROM pipelines ORDER BY created_at DESC")
+            pipeline_ids = [pipeline['id'] for pipeline in pipelines_data]
+
+            pipelines = []
+            for pipeline_id in pipeline_ids:  # TODO: some optimization here would be great, no duplicate call to get the pipeline, and parallelism 
+                pipeline = await self.get_pipeline(pipeline_id)
+                pipelines.append(pipeline)
+
+            return pipelines
+
+        async def get_pipeline(self, id: int) -> Pipeline | None:
+            """
+            Retrieve a single pipeline by its ID.
+
+            :param id: The ID of the pipeline to retrieve
+            :return: The Pipeline object if found, otherwise None
+            """
+            pipeline_raw = await self.db_svc.query("SELECT id, name, type, cron_string, configs, created_at FROM pipelines WHERE id = $1", id)
+            if not pipeline_raw:
+                return None
+
+            return Pipeline(
+                id=pipeline_raw[0]['id'],
+                name=pipeline_raw[0]['name'],
+                type=pipeline_raw[0]['type'],
+                cron_string=pipeline_raw[0]['cron_string'],
+                configs=pipeline_raw[0]['configs'], 
+            )
+
+        async def update_pipeline(self, pipeline_id: int, request: UpdatePipelineRequest) -> Pipeline | None:
+            """
+            Update a pipeline. Only updates fields that are provided.
+
+            :param pipeline_id: The ID of the pipeline to update
+            :param request: UpdatePipelineRequest object containing updated pipeline details
+            :return: The updated Pipeline object if found, None if the pipeline does not exist
+            """
+            # Check if pipeline exists
+            existing_pipeline = await self.db_svc.query("SELECT id FROM pipelines WHERE id = $1", pipeline_id)
+            if not existing_pipeline:
+                return None
+
+            # Update pipeline name if provided
+            if request.name is not None:
+                await self.db_svc.query("UPDATE pipelines SET name = $1 WHERE id = $2", request.name, pipeline_id)
+
+            return await self.get_pipeline(pipeline_id)
+
+        async def delete_pipeline(self, id: int) -> None:
+            """
+            Delete a pipeline by its ID.
+            :param id: The ID of the pipeline to delete
+            """
+            await self.db_svc.query("DELETE FROM pipelines WHERE id = $1", id)


### PR DESCRIPTION
Created a REST API that exposes the CRUD service for pipelines over HTTP. For now I made the configs type a text/string but later we need to define it as JSON. 

1. POST /pipelines
2. GET /pipelines
3. GET /pipelines/:id
4. PATCH /pipelines/:id
5. DELETE /pipelines/:id

Tested using swagger ui:
<img width="1122" height="418" alt="image" src="https://github.com/user-attachments/assets/4da973e1-0c99-4ed4-a638-5f5984f3a9d8" />

Also created table in the docker psql database:
<img width="1268" height="1158" alt="image" src="https://github.com/user-attachments/assets/7080b17c-cd7b-4e82-84de-66a09acb99ec" />
